### PR TITLE
Delete database created for tests

### DIFF
--- a/Backend/Sppd.TeamTuner.Core/Config/GeneralConfig.cs
+++ b/Backend/Sppd.TeamTuner.Core/Config/GeneralConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Sppd.TeamTuner.Core.Config
+﻿using Sppd.TeamTuner.Core.Domain.Enumerations;
+
+namespace Sppd.TeamTuner.Core.Config
 {
     /// <summary>
     ///     General configuration.
@@ -10,6 +12,11 @@
         ///     Specifies if Swagger UI will be enabled
         /// </summary>
         public bool EnableSwaggerUI { get; set; }
+
+        /// <summary>
+        ///     Specifies in which mode the application is being executed
+        /// </summary>
+        public ExecutionMode ExecutionMode { get; set; }
 
         public string SectionKey => "General";
     }

--- a/Backend/Sppd.TeamTuner.Core/Domain/Enumerations/ExecutionMode.cs
+++ b/Backend/Sppd.TeamTuner.Core/Domain/Enumerations/ExecutionMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Sppd.TeamTuner.Core.Domain.Enumerations
+{
+    public enum ExecutionMode
+    {
+        Unkown = 0,
+        Online = 1,
+        Test = 2
+    }
+}

--- a/Backend/Sppd.TeamTuner.Core/IShutdownRegistrator.cs
+++ b/Backend/Sppd.TeamTuner.Core/IShutdownRegistrator.cs
@@ -1,0 +1,10 @@
+﻿namespace Sppd.TeamTuner.Core
+{
+    public interface IShutdownRegistrator
+    {
+        /// <summary>
+        ///     Called before the application shuts down.
+        /// </summary>
+        void OnBeforeShutdown();
+    }
+}

--- a/Backend/Sppd.TeamTuner.Infrastructure.DataAccess.EF.Sqlite/StartupShutdownRegistrator.cs
+++ b/Backend/Sppd.TeamTuner.Infrastructure.DataAccess.EF.Sqlite/StartupShutdownRegistrator.cs
@@ -4,16 +4,35 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 using Sppd.TeamTuner.Core;
+using Sppd.TeamTuner.Core.Config;
+using Sppd.TeamTuner.Core.Domain.Enumerations;
 using Sppd.TeamTuner.Core.Services;
 using Sppd.TeamTuner.Core.Utils.Extensions;
 using Sppd.TeamTuner.Infrastructure.DataAccess.EF.Config;
 
 namespace Sppd.TeamTuner.Infrastructure.DataAccess.EF.Sqlite
 {
-    public class StartupRegistrator : IStartupRegistrator
+    public class StartupShutdownRegistrator : IStartupRegistrator, IShutdownRegistrator
     {
         private const string PROVIDER_NAME = "Sqlite";
         private const string ID_PLACEHOLDER = "{id}";
+
+        private IServiceProvider _serviceProvider;
+
+        public void OnBeforeShutdown()
+        {
+            var databaseConfig = _serviceProvider.GetConfig<DatabaseConfig>();
+            if (!PROVIDER_NAME.Equals(databaseConfig.Provider, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return;
+            }
+
+            var generalConfig = _serviceProvider.GetConfig<GeneralConfig>();
+            if (generalConfig.ExecutionMode == ExecutionMode.Test)
+            {
+                _serviceProvider.GetService<IDatabaseService>().DeleteDatabase();
+            }
+        }
 
         public int Priority => 90;
 
@@ -35,6 +54,7 @@ namespace Sppd.TeamTuner.Infrastructure.DataAccess.EF.Sqlite
 
         public void Configure(IServiceProvider serviceProvider)
         {
+            _serviceProvider = serviceProvider;
         }
     }
 }

--- a/Backend/Sppd.TeamTuner/Config/appsettings.json
+++ b/Backend/Sppd.TeamTuner/Config/appsettings.json
@@ -1,11 +1,12 @@
 {
   "General": {
-    "EnableSwaggerUI": true
+    "EnableSwaggerUI": true,
+    "ExecutionMode": "Online"
   },
   "Database": {
     // Swap comments on below lines to use Sqlite
     //"Provider":  "Sqlite", 
-    //"ConnectionString": "Data Source=sppd.teamtuner.db",
+    //"ConnectionString": "Data Source=Sppd.TeamTuner.db",
     "Provider": "MsSql",
     "ConnectionString": "Data Source=.\\SQLEXPRESS; Initial Catalog=Sppd.TeamTuner-DEV; Integrated Security=true; MultipleActiveResultSets=True;",
     "AutoMigrate": true,

--- a/Backend/Sppd.TeamTuner/Startup.cs
+++ b/Backend/Sppd.TeamTuner/Startup.cs
@@ -86,7 +86,8 @@ namespace Sppd.TeamTuner
         /// </summary>
         /// <param name="app">The application builder.</param>
         /// <param name="env">The hosting environment.</param>
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        /// <param name="appLifetime">The application lifetime.</param>
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime appLifetime)
         {
             _logger.LogDebug("Start configuring application");
 
@@ -122,7 +123,18 @@ namespace Sppd.TeamTuner
 
             ConfigureServicesOnStartupRegistries(app.ApplicationServices);
 
+            appLifetime.ApplicationStopping.Register(OnBeforeShutdown);
+
             _logger.LogInformation("Application is ready");
+        }
+
+        private void OnBeforeShutdown()
+        {
+            _logger.LogInformation("Application is shutting down");
+            foreach (var shutdownRegistrator in GetInstances<IShutdownRegistrator>())
+            {
+                shutdownRegistrator.OnBeforeShutdown();
+            }
         }
 
         private static void RegisterSwagger(IServiceCollection services)

--- a/Backend/Tests/Sppd.TeamTuner.Tests.Integration.Api/Config/appsettings.json
+++ b/Backend/Tests/Sppd.TeamTuner.Tests.Integration.Api/Config/appsettings.json
@@ -1,10 +1,11 @@
 {
   "General": {
-    "EnableSwaggerUI": true
+    "EnableSwaggerUI": true,
+    "ExecutionMode":  "Test" 
   },
   "Database": {
     "Provider": "Sqlite",
-    "ConnectionString": "Data Source=Sppd.TeamTuner-TEST-API.db",
+    "ConnectionString": "Data Source=Sppd.TeamTuner-TEST-API-{id}.db",
     "AutoMigrate": true,
     "SeedMode": "Test",
     "DeleteOnStartup": true

--- a/Backend/Tests/Sppd.TeamTuner.Tests.Integration/Config/appsettings.json
+++ b/Backend/Tests/Sppd.TeamTuner.Tests.Integration/Config/appsettings.json
@@ -1,6 +1,7 @@
 {
   "General": {
-    "EnableSwaggerUI": true
+    "EnableSwaggerUI": true,
+    "ExecutionMode": "Test"
   },
   "Database": {
     "Provider":  "Sqlite", 

--- a/Backend/Tests/Sppd.TeamTuner.Tests.Integration/RepositoryTestsBase.cs
+++ b/Backend/Tests/Sppd.TeamTuner.Tests.Integration/RepositoryTestsBase.cs
@@ -29,8 +29,8 @@ namespace Sppd.TeamTuner.Tests.Integration
         {
             // Instantiate StartupRegistrators registering required services
             var dataAccessStartupRegistrator = new StartupRegistrator();
-            var msSqlStartupRegistrator = new Infrastructure.DataAccess.EF.MsSql.StartupRegistrator();
-            var sqliteStartupRegistrator = new Infrastructure.DataAccess.EF.Sqlite.StartupRegistrator();
+            var msSqlStartupRegistrator = new Infrastructure.DataAccess.EF.MsSql.StartupShutdownRegistrator();
+            var sqliteStartupRegistrator = new Infrastructure.DataAccess.EF.Sqlite.StartupShutdownRegistrator();
             var infrastructureStartupRegistrator = new Infrastructure.StartupRegistrator();
             var startupRegistrators = new IStartupRegistrator[]
                                       {


### PR DESCRIPTION
Added mechanism to delete databases having been created by API tests when the application stops.

It doesn't work though, `Startup.OnBeforeShutdown()` is never being called. Why? 